### PR TITLE
Added control mechanisms when generating yaml data

### DIFF
--- a/yaml-generation/functions.php
+++ b/yaml-generation/functions.php
@@ -209,7 +209,7 @@ function getActivityNameByUuid($uuid, $dimensionsAggregated) {
             }
         }
     }
-    return "TODO:Mapping";
+    return null;
 }
 
 

--- a/yaml-generation/functions.php
+++ b/yaml-generation/functions.php
@@ -227,11 +227,6 @@ function getActivityByActivityName($activityName, $dimensionsAggregated) {
     foreach ($dimensionsAggregated as $dimension => $subdimensions) {
         ksort($subdimensions);
         foreach ($subdimensions as $subdimension => $elements) {
-            if (sizeof($elements) == 0) {
-                echo "unsetting $subdimension\n";
-                unset($dimensionsAggregated[$dimension][$subdimension]);
-                continue;
-            }
             if (substr($subdimension, 0, 1) == "_") {
                 continue;
             }

--- a/yaml-generation/functions.php
+++ b/yaml-generation/functions.php
@@ -213,6 +213,38 @@ function getActivityNameByUuid($uuid, $dimensionsAggregated) {
 }
 
 
+function getUuidByActivityName($activityName, $dimensionsAggregated) {
+    $activity = getActivityByActivityName($activityName, $dimensionsAggregated);
+    if ($activity) {
+        return $activity["uuid"];
+    } else {
+        return null;
+    }
+}
+
+
+function getActivityByActivityName($activityName, $dimensionsAggregated) {
+    foreach ($dimensionsAggregated as $dimension => $subdimensions) {
+        ksort($subdimensions);
+        foreach ($subdimensions as $subdimension => $elements) {
+            if (sizeof($elements) == 0) {
+                echo "unsetting $subdimension\n";
+                unset($dimensionsAggregated[$dimension][$subdimension]);
+                continue;
+            }
+            if (substr($subdimension, 0, 1) == "_") {
+                continue;
+            }
+
+            if (array_key_exists($activityName, $elements)) {
+                return $elements[$activityName];
+            }
+        }
+    }
+    return null;
+}
+
+
 /**
  *
  * @param unknown $headings

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -70,6 +70,7 @@ foreach ($dimensionsAggregated as $dimension => $subdimensions) {
                 exit;
 	        }
 	    
+            echo "$subdimension | $activityName\n";
             if (!array_key_exists("uuid", $activity)) {
                 array_push($errorMsg, "$activityName is missing an uuid in $dimension");
             } else {
@@ -123,26 +124,29 @@ foreach ($dimensionsAggregated as $dimension => $subdimensions) {
                 unset($dimensionsAggregated[$dimension][$subdimension][$activityName]["evidence"]);
             }
             if (array_key_exists("dependsOn", $activity)) {
-                foreach($activity['dependsOn'] as $index => $dependingElement) {
-                    if(!is_string($dependingElement)) {
-                        array_push($errorMsg, "The 'dependsOn' is not a string in $activityName: $dependingElement");
+                foreach($activity['dependsOn'] as $index => $dependsOn) {
+                    if(!is_string($dependsOn)) {
+                        array_push($errorMsg, "The 'dependsOn' is not a string '" . json_encode($dependsOn) . "' (in $activityName)");
                         continue;
-                    }
+                    } 
+
+                    // Swap uuids with activity name
                     $uuidRegExp = "/(uuid:)?\s*([0-9a-f]{6,}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{6,})/";
-                    if (preg_match($uuidRegExp, $dependingElement, $matches)) {
+                    if (preg_match($uuidRegExp, $dependsOn, $matches)) {
                         $dependsOnUuid = $matches[2];
-                        $dependsOnActivityName = getActivityNameByUuid($dependsOnUuid, $dimensionsAggregated);
-                        if (is_null($dependsOnActivityName)) {
+                        $dependsOn = getActivityNameByUuid($dependsOnUuid, $dimensionsAggregated);
+                        if (is_null($dependsOn)) {
                             array_push($errorMsg,"DependsOn non-existing activity uuid: $dependsOnUuid  (in activity: $activityName)");
                         } else if ($matches[1] == "") {
                             echo "WARNING: DependsOn is not prefixed by 'uuid:' for $dependsOnUuid (in activity: $activityName)\n";
-                        }
-    
-                        $dimensionsAggregated[$dimension][$subdimension][$activityName]["dependsOn"][$index] = $dependsOnActivityName;
-                        // echo "exchanged $dependingElement to name $dependsOnActivityName\n";
+                        } 
+                        
+                        // echo "exchanged $dependsOnUuid with name $dependsOnActivityName\n";
+                        $dimensionsAggregated[$dimension][$subdimension][$activityName]["dependsOn"][$index] = $dependsOn;
+                        
                     } else {
-                        if (is_null(getUuidByActivityName($dependingElement, $dimensionsAggregated))) {
-                            array_push($errorMsg,"DependsOn non-existing activity: '$dependingElement' (in activity: $activityName)");
+                        if (is_null(getUuidByActivityName($dependsOn, $dimensionsAggregated))) {
+                            array_push($errorMsg,"DependsOn non-existing activity: '$dependsOn' (in activity: $activityName)");
                         }
                     }
                 }

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -134,7 +134,7 @@ foreach ($dimensionsAggregated as $dimension => $subdimensions) {
                         $dependsOnUuid = str_replace("uuid:", "", $dependingElement);
                         $dimensionsAggregated[$dimension][$subdimension][$activityName]["dependsOn"][$index] = $dependsOnUuid;
                         $dependsOnActivityName = getActivityNameByUuid($dependsOnUuid, $dimensionsAggregated);
-                        echo "exchanged $dependingElement to name $dependsOnActivityName";
+                        $dimensionsAggregated[$dimension][$subdimension][$activityName]["dependsOn"][$index] = $dependsOnActivityName;
                     }
                 }
             }

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -63,11 +63,7 @@ foreach ($dimensionsAggregated as $dimension => $subdimensions) {
 
         foreach ($elements as $activityName => $activity) {
             if (!array_key_exists("level", $activity)) {
-                echo "'$activityName' is not complete!";
-                echo "<pre>";
-                var_dump($activity);
-                echo "</pre>";
-                exit;
+                array_push($errorMsg,"Missing 'level' attribute in activity: $activityName");
 	        }
 	    
             echo "$subdimension | $activityName\n";


### PR DESCRIPTION
@wurstbrot: I've added some error checking to the yaml generation. My change is alerting when:
 - Alert if activity is missing UUID
 - Alert if duplicate activity UUIDs are found
 - Alert duplicate activity names are present
 - Fixed exchanging dependsOn uuids with activityName
 - Alert if DependsOn uuid does not match any activities
 - Alert if DependsOn activityName does not match any activities

This change uncovered two incorrect dependsOn references:
 - `Defined deployment process` depends on non-existing `Continuous Integration`
 - `Test network segmentation` depends on non-existing `Segmented networks for virtual environments`
 
 I have not corrected these dependencies. 