### PR TITLE
Added control mechanisms for implemenation references

### DIFF
--- a/src/assets/YAML/default/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/src/assets/YAML/default/CultureAndOrganization/EducationAndGuidance.yaml
@@ -19,7 +19,7 @@ Culture and Organization:
       level: 1
       implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juice-shop
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-ser
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-series
       references:
         samm2:
           - G-EG-1-A
@@ -273,7 +273,7 @@ Culture and Organization:
         [Source: OWASP SAMM 2](https://owaspsamm.org/model/governance/education-and-guidance/stream-a/)
       implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juice-shop
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-ser
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-series
       references:
         samm2:
           - G-EG-1-A
@@ -298,7 +298,7 @@ Culture and Organization:
       level: 4
       implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juice-shop
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/https-cheatsheetse
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-series
       references:
         samm2:
           - G-EG-3-A
@@ -323,7 +323,7 @@ Culture and Organization:
       usefulness: 5
       level: 2
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-ser
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-series
       dependsOn:
         - Each team has a security champion
       references:
@@ -420,7 +420,7 @@ Culture and Organization:
       usefulness: 3
       level: 1
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-ser
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-series
       references:
         samm2:
           - G-EG-1-A

--- a/src/assets/YAML/default/CultureAndOrganization/EducationAndGuidance.yaml
+++ b/src/assets/YAML/default/CultureAndOrganization/EducationAndGuidance.yaml
@@ -272,7 +272,7 @@ Culture and Organization:
 
         [Source: OWASP SAMM 2](https://owaspsamm.org/model/governance/education-and-guidance/stream-a/)
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juiceshop
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juice-shop
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-cheatsheet-ser
       references:
         samm2:
@@ -297,7 +297,7 @@ Culture and Organization:
       usefulness: 4
       level: 4
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juiceshop
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-juice-shop
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/https-cheatsheetse
       references:
         samm2:

--- a/src/assets/YAML/default/Implementation/InfrastructureHardening.yaml
+++ b/src/assets/YAML/default/Implementation/InfrastructureHardening.yaml
@@ -406,7 +406,7 @@ Implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/cis-docker-bench-for
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/for-example-for-cont
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-cloud
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-contai
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-containers
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-kubern
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/defend-the-core-kubernetes
       references:
@@ -439,7 +439,7 @@ Implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/cis-docker-bench-for
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/for-example-for-cont
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-cloud
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-contai
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-containers
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/attack-matrix-kubern
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/defend-the-core-kubernetes
       references:

--- a/src/assets/YAML/default/TestAndVerification/Consolidation.yaml
+++ b/src/assets/YAML/default/TestAndVerification/Consolidation.yaml
@@ -159,7 +159,7 @@ Test and Verification:
       usefulness: 4
       level: 1
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-defect-dojo
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-defectdojo
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/purify
       references:
         samm2:

--- a/src/assets/YAML/default/implementations.yaml
+++ b/src/assets/YAML/default/implementations.yaml
@@ -191,20 +191,6 @@ implementations:
   owasp-cheatsheet-ser:
     uuid: 1c3f2f7a-5031-4687-9d69-76c5178c74e1
     name: OWASP Cheatsheet Series
-    tags: [secure coding]
-    url: https://cheatsheetseries.owasp.org/
-  owasp-juiceshop:
-    uuid: 81476121-67dd-4ba9-a67b-e78a23050c28
-    name: OWASP JuiceShop
-    tags: []
-    url: https://github.com/bkimminich/juice-shop
-    description:
-      "In case you do not have the budget to hire an external security\
-      \ expert, an option\nis to use the [OWASP JuiceShop](https://github.com/bkimminich/juice-shop)\
-      \ on a \"hacking Friday\""
-  https-cheatsheetse:
-    uuid: 99080ac7-60cd-46af-93a1-a53a33597cba
-    name: https://cheatsheetseries.owasp.org/
     tags: [training, secure coding]
     url: https://cheatsheetseries.owasp.org/
   owasp-security-champ:
@@ -286,7 +272,7 @@ implementations:
     uuid: 59881520-4c69-4922-a44e-99044a77de2b
     name: Attack Matrix Containers
     tags: [mitre]
-    url: https://attack.mitre.org/matrices/enterprise/cloud/
+    url: https://attack.mitre.org/matrices/enterprise/containers/
     description: |-
       Attack matrix for containers
   attack-matrix-kubern:
@@ -465,11 +451,6 @@ implementations:
     uuid: 73f6a52c-4fc2-45dc-991b-d5911b6c1ef8
     name: collected
     tags: []
-  httpunit:
-    uuid: 3bd40005-f180-4b95-907d-ec5b58ac1f20
-    name: HttpUnit
-    tags: []
-    url: http://httpunit.sourceforge.net/
   junit:
     uuid: cc2eec82-f3a7-4ae5-9ccb-3d75352b2e4d
     name: JUnit
@@ -501,10 +482,6 @@ implementations:
     url: https://github.com/MaibornWolff/SecObserve
     description: |
       The aim of SecObserve is to make vulnerability scanning and vulnerability management as easy as possible for software development projects using open source tools.
-  see-other-actions-e:
-    uuid: 44c08670-78dc-47ee-a4c1-2503ca6b6cf8
-    name: See other actions, e.g. "Treatment of defects with severity high".
-    tags: []
   sast:
     uuid: aaad322e-806e-4c51-b78d-6551f7dc376a
     name: SAST
@@ -522,11 +499,6 @@ implementations:
       "At DAST (Dynamic Application Security Testing): vulnerabilities
       are classified and can be assigned to server-side and client-side teams."
     url: https://d3fend.mitre.org/dao/artifact/d3f:DynamicAnalysisTool/
-  owasp-defect-dojo:
-    uuid: bb9d0f2d-f8bc-46b5-bbc7-7dbcf927191c
-    name: OWASP Defect Dojo
-    tags: []
-    url: https://github.com/DefectDojo/django-DefectDojo
   owasp-dependency-che:
     uuid: 06334caf-8be6-487a-96b1-d41c7ed5f207
     name: OWASP Dependency Check
@@ -816,45 +788,6 @@ implementations:
     name: Dependency-Track is an intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain. Dependency-Track takes a unique and highly beneficial approach by leveraging the capabilities of Software Bill of Materials (SBOM).
     url: https://github.com/DependencyTrack/dependency-track
     tags: [sca, inventory, OpenSource, "Supply Chain", vulnerability, inventory]
-  juice-shop:
-    uuid: c021aa72-c71c-43e4-9573-717b74d6c19d
-    name: OWASP Juice Shop
-    tags: [training]
-    url: https://github.com/bkimminich/juice-shop
-    description: |-
-      In case you do not have the budget to hire an external security expert, an option is to use the OWASP JuiceShop on a "hacking Friday"
-  dvwa:
-    uuid: e1282ab3-7ffd-4ee5-a564-8e9af070979d
-    name: Damn Vulnerable Web Application
-    tags: [training]
-    description: |-
-      Simple Application with intended vulnerabilities. HTML based.
-  loggingCheatSheet:
-    uuid: 032ca7cc-67dc-46bc-9702-3580a3c9d1a9
-    name: OWASP Logging CheatSheet
-    url: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
-    tags: [logging, documentation]
-  zap:
-    uuid: 84a2a907-a6fb-4ceb-8e21-f65c0d633445
-    name: OWASP Zap
-    tags: [vulnerability, scanner]
-    url: https://github.com/zaproxy/zaproxy
-    description: |
-      The OWASP Zed Attack Proxy (ZAP) is one of the world's most popular free security tools and is actively maintained by a dedicated international team of ...
-  secureCodeBox:
-    uuid: dc0995a5-ff13-4cfc-b95f-07bf8a30b6ab
-    name: OWASP secureCodeBox
-    tags: [vulnerability, scanner-orchestration]
-    url: https://github.com/secureCodeBox/secureCodeBox
-    description: |
-      secureCodeBox is a kubernetes based, modularized toolchain for continuous security scans of your software project. Its goal is to orchestrate and easily automate a bunch of security-testing tools out of the box.
-  K8sPurger:
-    uuid: 7a019f5e-a77d-4f4a-89a6-d5107054a2cb
-    name: K8sPurger
-    tags: [vulnerability, scanner, dast, infrastructure]
-    url: https://github.com/yogeshkk/K8sPurger
-    description: |
-      Hunt Unused Resources In Kubernetes.
   hashicorp-vault:
     uuid: e3a2ffc8-313f-437e-9663-b24591568209
     name: Hashicorp Vault

--- a/src/assets/YAML/default/implementations.yaml
+++ b/src/assets/YAML/default/implementations.yaml
@@ -188,7 +188,7 @@ implementations:
     url: https://github.com/bkimminich/juice-shop
     description: |-
       In case you do not have the budget to hire an external security expert, an option is to use the OWASP JuiceShop on a "hacking Friday"
-  owasp-cheatsheet-ser:
+  owasp-cheatsheet-series:
     uuid: 1c3f2f7a-5031-4687-9d69-76c5178c74e1
     name: OWASP Cheatsheet Series
     tags: [training, secure coding]
@@ -268,7 +268,7 @@ implementations:
     url: https://attack.mitre.org/matrices/enterprise/cloud/
     description: |-
       Attack matrix for cloud
-  attack-matrix-contai:
+  attack-matrix-containers:
     uuid: 59881520-4c69-4922-a44e-99044a77de2b
     name: Attack Matrix Containers
     tags: [mitre]

--- a/yaml-generation/bib.php
+++ b/yaml-generation/bib.php
@@ -14,11 +14,17 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 define('NUMBER_LEVELS', 4);
-if (isset($_ENV["IS_IMPLEMENTED_WHEN_EVIDENCE"])) {
-    $enforce=boolval($_ENV["IS_IMPLEMENTED_WHEN_EVIDENCE"]);
-    define('IS_IMPLEMENTED_WHEN_EVIDENCE', $enforce);
-}else {
-    define('IS_IMPLEMENTED_WHEN_EVIDENCE', false);
+defineConstFromEnv("IS_IMPLEMENTED_WHEN_EVIDENCE");
+defineConstFromEnv("TEST_REFERENCED_URLS");
+
+
+function defineConstFromEnv($envVar) {
+    if (isset($_ENV[$envVar])) {
+        $value = boolval($_ENV[$envVar]);
+        define($envVar, $value);
+    }else {
+        define($envVar, false);
+    }
 }
 
 /**

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -289,13 +289,25 @@ function resolveYamlReferences(&$data, $references, &$errorMsg)
 
             // Insert the actual reference object, instead of the reference link
             $value = $payload['references'][$context][$ref];
+            $payload['usedRefs']["$context/$ref"] = true;
         }
     }
 
 
     // Call resolve_yaml_references_cb for each and every node in the data array
-    $payload = array('references' => &$references, 'errorMsg' => &$errorMsg);
+    $usedRefs = array();
+    $payload = array('references' => &$references, 'errorMsg' => &$errorMsg, 'usedRefs' => &$usedRefs);
     array_walk($data, "resolveYamlReferencesCallback", $payload);
+
+    // Inform of unused references
+    echo "\n";
+    foreach ($references as $context => $refs) {
+        foreach ($refs as $ref => $refData) {
+            if (!array_key_exists("$context/$ref", $usedRefs)) {
+                echo "INFO: Reference never used: $context: $ref\n";
+            }
+        }
+    }
 }
 
 

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -165,6 +165,7 @@ foreach ($dimensionsAggregated as $dimension => $subdimensions) {
 $implementationReferences = readYaml($implementationReferenceFile)['implementations'];
 $references = array("implementations" => $implementationReferences);
 assertUniqueRefs($references, $errorMsg);
+assertSecureUrlsInRefs($references, $errorMsg);
 assertLiveUrlsInRefs($references, $errorMsg);
 
 resolveYamlReferences($dimensionsAggregated, $references, $errorMsg);
@@ -210,6 +211,22 @@ function assertUniqueRefByKey($references, $keyToAssert, &$errorMsg) {
                 array_push($errorMsg, "Duplicate '$keyToAssert' in reference file: " . $all_values[$value] . " and $key: $printable_keyToAssert='$value'");
             } else {
                 $all_values[$value] = $key;
+            }
+        }
+    }
+}
+
+
+function assertSecureUrlsInRefs($all_references, &$errorMsg) {
+    foreach ($all_references as $references) {
+        foreach ($references as $id => $reference) {
+            foreach ($reference as $key => $value) {   
+                if (is_string($value)) {
+                    // echo "KEY: $key VAL: " . var_dump($value) . "\n";
+                    if (str_contains($value,'http://')) {
+                        array_push($errorMsg, "Insecure url in '$key' of $id: " . $reference[$key]);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
An extension of PR #29. This PR is controlling references, and reports:
 - duplicate uuids in references
 - duplicate urls in references
 - duplicate names in references
 - duplicate descriptions in references
 - unused references (as INFO, not ERROR)
 - referencing http links instead of https

I have identified and tidied some duplicates in `implementations.yaml` (such as `juice-shop`, `owasp-juice-shop`, `zap`, `owasp-zap`, etc).  

I have left two duplicate URLs issues. I presume they were supposed to link to to different pages, as the two references are both referred from the same activity. 

## Live URLs?
If you include the runtime environment variable `docker run  -e TEST_REFERENCED_URLS=true  ...` the script will now also loop through all URLs in the `implementations.yaml` and test if they are still alive.

This is a bit more tricky, as websites such as https://thehackernews.com/ implement defenses against spiders.  Therefore it this will report some false positives.

The current implementation reports any status not equal to 200. Including redirects such as 301 and 302.

### Request for Comments
Please treat this as a Request-for-Comments, @wurstbrot. I'm open for discussion on several issues. For example: 
 - Is this a feature that is needed?
 - 301 and 302 may indicate that a page has been moved (and the reference should be updated), or it may be a false alarm
 - 403 and 404 may also be false alarms. Should we have a way to "acknowledge" an error, to avoid repetitive alerts? How then do we detect is this page later goes offline, in that case?