### PR TITLE
Fixed typo in dependsOn reference

### DIFF
--- a/src/assets/YAML/default/TestAndVerification/Consolidation.yaml
+++ b/src/assets/YAML/default/TestAndVerification/Consolidation.yaml
@@ -198,7 +198,7 @@ Test and Verification:
       usefulness: 3
       level: 2
       dependsOn:
-        - uuid: c1acc8af-312e-4503-a817-a26220c993a0 # Simple false positive treatment
+        - c1acc8af-312e-4503-a817-a26220c993a0 # Simple false positive treatment
       implementation:
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/owasp-defectdojo
         - $ref: src/assets/YAML/default/implementations.yaml#/implementations/purify
@@ -345,8 +345,8 @@ Test and Verification:
       usefulness: 4
       level: 3
       dependsOn:
-        - uuid: 8f2b4d5a-3c1e-4b7a-9d8f-2e6c4a1b5d7f # Artifact-based false positive treatment
-        - uuid: 85ba5623-84be-4219-8892-808837be582d # Usage of a vulnerability management system
+        - 8f2b4d5a-3c1e-4b7a-9d8f-2e6c4a1b5d7f # Artifact-based false positive treatment
+        - 85ba5623-84be-4219-8892-808837be582d # Usage of a vulnerability management system
       implementation:
       references:
         samm2:


### PR DESCRIPTION
The YAML interpretation of:
```
dependsOn:
  - uuid: abcd
  - uuid: efgh
```
is different from:
```
dependsOn:
  - uuid:abcd
  - uuid:efgh

```
(See the difference at: https://yaml-online-parser.appspot.com/)


## Questions
I would actually recommend skipping the "uuid:" part altogether, @wurstbrot. It is very easy to incorrectly add this space character. 

The `generateDimensions.php` is pretty close to accepting UUIDs in `dependsOn`. It already identifies uuids and comes with a warning if the `uuid:` is missing. It accepts both uuids and activity names as input.

* One important question, though, @wurstbrot: Should the output form `generateDimensions.php` contain the _uuid_, of the _activity name_?



