### PR TITLE
Generate dependency tree as markdown

### DIFF
--- a/yaml-generation/functions.php
+++ b/yaml-generation/functions.php
@@ -319,6 +319,16 @@ function getReferences($references) {
 
 }
 
+/**
+ * Push item to array at key, creating array if needed.
+ */
+function array_push_item_to(array &$array, $key, $value) {
+    if (!isset($array[$key])) {
+        $array[$key] = [];
+    }
+    array_push($array[$key], $value);
+}
+
 
 // TODO create testcases
 


### PR DESCRIPTION
To get a better overview of the dependencies, I recommend that we generate this markdown file whenever we generate the yaml file.

I have not been able to test running it on Linux, @wurstbrot. But looks to be running fine on Windows. Please verify :)