### PR TITLE
feat: Improved start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ To test all URLs referenced by `implementations.yaml` and save results to `url-t
 
 ### Using Podman instead of Docker
 
-If you prefer Podman over Docker, edit the script and set the `DOCKER` variable to `podman`. For example:
- - Linux: `DOCKER=podman` 
- - Windows: `set DOCKER=podman`
+If you prefer Podman over Docker, set the environement variable `DOCKER_CMD` to `podman`, or edit the script for you operating system.
 
 
 ## Credits

--- a/yaml-generation/generateDimensions.bash
+++ b/yaml-generation/generateDimensions.bash
@@ -9,22 +9,24 @@ cd "$(dirname "$0")"/..
 pwd 
 
 # Use: docker | podman
-DOCKER=docker 
+if [ -z "${DOCKER_CMD}" ]; then
+    DOCKER_CMD=docker
+fi
 
 if [ "$1" = "--install" ]; then
     echo Installing composer dependencies...
-    MSYS_NO_PATHCONV=1 $DOCKER run -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/yaml-generation && composer install --no-interaction --no-plugins --no-scripts --prefer-dist'
+    MSYS_NO_PATHCONV=1 $DOCKER_CMD run -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/yaml-generation && composer install --no-interaction --no-plugins --no-scripts --prefer-dist'
 
 elif [ "$1" = "--start-dsomm" ]; then
     echo "Starting local DSOMM application..."
-    MSYS_NO_PATHCONV=1 $DOCKER run -ti --rm --volume $(pwd)/src/assets/YAML/generated/generated.yaml:/srv/assets/YAML/generated/generated.yaml -p 8080:8080 wurstbrot/dsomm
+    MSYS_NO_PATHCONV=1 $DOCKER_CMD run -ti --rm --volume $(pwd)/src/assets/YAML/generated/generated.yaml:/srv/assets/YAML/generated/generated.yaml -p 8080:8080 wurstbrot/dsomm
 
 elif [ "$1" = "--test-urls" ]; then
     echo "Test URLs in implementations.yaml..."
-    MSYS_NO_PATHCONV=1 $DOCKER run -e TEST_REFERENCED_URLS=true -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/ && php yaml-generation/generateDimensions.php' | tee url-test-results.txt
+    MSYS_NO_PATHCONV=1 $DOCKER_CMD run -e TEST_REFERENCED_URLS=true -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/ && php yaml-generation/generateDimensions.php' | tee url-test-results.txt
 
 else
     echo "Generating activities.yaml..."
-    MSYS_NO_PATHCONV=1 $DOCKER run -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/ && php yaml-generation/generateDimensions.php'
+    MSYS_NO_PATHCONV=1 $DOCKER_CMD run -ti --rm --volume ${PWD}:/app wurstbrot/dsomm-yaml-generation bash -c 'cd /app/ && php yaml-generation/generateDimensions.php'
 
 fi

--- a/yaml-generation/generateDimensions.bat
+++ b/yaml-generation/generateDimensions.bat
@@ -10,23 +10,25 @@ REM Change working directory to the project root
 cd %~dp0\..
 
 REM Use: docker | podman
-set DOCKER=docker
+if "%DOCKER_CMD%"=="" (
+    set DOCKER_CMD=docker
+)
 
 if "%~1"=="--install" (
     echo Installing composer dependencies...
-    %DOCKER% run -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/yaml-generation && composer install --no-interaction --no-plugins --no-scripts --prefer-dist"
+    %DOCKER_CMD% run -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/yaml-generation && composer install --no-interaction --no-plugins --no-scripts --prefer-dist"
 
 ) else if "%~1"=="--start-dsomm" (
     echo Start local DSOMM application...
-    %DOCKER% run -ti --rm --volume "%CD%/src/assets/YAML/generated/generated.yaml:/srv/assets/YAML/generated/generated.yaml" -p 8080:8080 wurstbrot/dsomm
+    %DOCKER_CMD% run -ti --rm --volume "%CD%/src/assets/YAML/generated/generated.yaml:/srv/assets/YAML/generated/generated.yaml" -p 8080:8080 wurstbrot/dsomm
 
 ) else if "%~1"=="--test-urls" (
     echo Test URLs in implementations.yaml...
-    %DOCKER% run -e TEST_REFERENCED_URLS=true -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/ && php yaml-generation/generateDimensions.php" | tee url-test-results.txt
+    %DOCKER_CMD% run -e TEST_REFERENCED_URLS=true -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/ && php yaml-generation/generateDimensions.php" | tee url-test-results.txt
 
 ) else (
     echo Generate activities.yaml...
-    %DOCKER% run -e %argument% -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/ && php yaml-generation/generateDimensions.php"
+    %DOCKER_CMD% run -e %argument% -ti --rm --volume "%CD%:/app" wurstbrot/dsomm-yaml-generation bash -c "cd /app/ && php yaml-generation/generateDimensions.php"
     
 )
 


### PR DESCRIPTION
Fixes #28.

As part of streamlining the scart script, I also found out how to fix the issue #28. You had already made a comment in the `meta-on-top` branch, and as comments in the bash script.

With this PR, one can use:
```
    ./generateDimensions.bash --install       First time, install composer dependencies
    ./generateDimensions.bash                 Generate activities.yaml
    ./generateDimensions.bash --test-urls     Test URLs in implementations.yaml
    ./generateDimensions.bash --start-dsomm   Start a local DSOMM app
```