### PR TITLE
fix: Sort activities by level, within each sub-dimension

### DIFF
--- a/yaml-generation/functions.php
+++ b/yaml-generation/functions.php
@@ -136,6 +136,21 @@ function getDimensions($filename = "data/generated/dimensions.yaml") {
     return $dimensions;
 }
 
+/**
+ * Sort activities by their 'level' attribute within each subdimension.
+ * The uasort() is stable, i.e. it will retain the original order, within each level.
+ */
+function sortActivitiesByLevel($dimensions) {
+    foreach ($dimensions as $dimension => $subdimensions) {
+        foreach ($subdimensions as $subdimension => $elements) {
+            uasort($elements, function($a, $b) {
+                return ($a['level'] ?? 0) <=> ($b['level'] ?? 0);
+            });
+            $dimensions[$dimension][$subdimension] = $elements;
+        }
+    }
+    return $dimensions;
+}   
 
 
 /**

--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -16,6 +16,7 @@ foreach ($files as $filename) {
     }
     $dimensions = array_merge_recursive($dimensions, $dimension);
 }
+$dimensions = sortActivitiesByLevel($dimensions);
 
 $files = glob("src/assets/YAML/custom/*/*.yaml");
 $dimensionsCustom = array();


### PR DESCRIPTION
This PR sorts activities by their level, within each sub-dimension. 

This leads to a more intuitive order when exporting the activities to Excel, as well as when you manually go though the generated output in the DSOMM application. 

The sorted order of activities of the same level will remain the same as in the source.

So the currect source file for Build:
 -  Build - Level 2 - Building and testing of artifacts in virtual environments 
 -  Build - Level 1 - Defined build process
 -  Build - Level 2 - Pinning of artifacts
 -  Build - Level 2 - SBOM of components
 -  Build - Level 5 - Signing of artifacts
 -  Build - Level 3 - Signing of code

Will become:
 -  Build - Level 1 - Defined build process
 -  Build - Level 2 - Building and testing of artifacts in virtual environments 
 -  Build - Level 2 - Pinning of artifacts
 -  Build - Level 2 - SBOM of components
 -  Build - Level 3 - Signing of code
 -  Build - Level 5 - Signing of artifacts
