### PR TITLE
Replace broken sonarqube like

### DIFF
--- a/src/assets/YAML/default/implementations.yaml
+++ b/src/assets/YAML/default/implementations.yaml
@@ -752,7 +752,7 @@ implementations:
   sonarqube:
     uuid: aa5ded61-5380-4da6-9474-afc36a397682
     name: In-Depth Linting of Your TypeScript While Coding
-    url: https://blog.sonarsource.com/in-depth-linting-of-your-typescript-while-coding
+    url: https://medium.com/@elenavilchik/in-depth-linting-of-your-typescript-while-coding-1d084affbf0
     tags: [ide, linting]
   stylecop:
     uuid: 0b7ec352-0c36-4de1-8912-617fc6c608fe


### PR DESCRIPTION
I would've liked to have checked the content matched but archive.org doesn't seem to have saved the old page.

I think the content on the medium.com link is likely the same though.