### PR TITLE
fix: ensure non-zero exit code for YAML errors in CI

### DIFF
--- a/yaml-generation/generateDimensions.php
+++ b/yaml-generation/generateDimensions.php
@@ -159,7 +159,8 @@ if (count($errorMsg) > 0) {
     foreach ($errorMsg as $e) {
         echo "ERROR: $e\n";
     }
-    exit("Please fix the errors");
+    fwrite(STDERR, "Please fix the errors\n");
+    exit(1);
 }
 
 


### PR DESCRIPTION
Hey, I noticed a small but important issue in our YAML generation script. Right now, when there’s an error, it uses exit("Please fix the errors"). In PHP, passing a string to exit() actually returns an exit code of 0—which tells CI systems that everything succeeded. That means our pipelines keep running even when the YAML is broken. As a result, Docker builds end up using an old model.yaml, and we don’t even realize there’s a problem until something else fails.

To fix this, I’ve changed it to exit(1) so the script properly signals a failure. I also made sure the error message goes to STDERR using fwrite. This way, CI pipelines will stop as soon as an error happens, and we’ll get a clear error message instead of silently ignoring the problem.

This resolves #74.