### PR TITLE
fix: correct typo in blue-green-deployment implementation key

### DIFF
--- a/src/assets/YAML/default/BuildAndDeployment/Deployment.yaml
+++ b/src/assets/YAML/default/BuildAndDeployment/Deployment.yaml
@@ -15,7 +15,7 @@ Build and Deployment:
       usefulness: 2
       level: 5
       implementation:
-        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/blue-green-deploymen
+        - $ref: src/assets/YAML/default/implementations.yaml#/implementations/blue-green-deployment
       dependsOn:
         - Smoke Test
       references:

--- a/src/assets/YAML/default/implementations.yaml
+++ b/src/assets/YAML/default/implementations.yaml
@@ -70,7 +70,7 @@ implementations:
     uuid: 9af7624e-0729-4eeb-b257-ebaf65f70355
     name: A Point in Time Recovery for databases should be implemented.
     tags: []
-  blue-green-deploymen:
+  blue-green-deployment:
     uuid: 4fb3d95c-07c0-4cbb-b396-5054aba751c2
     name: Blue/Green Deployments
     tags: []


### PR DESCRIPTION
## Summary

`implementations.yaml` defines the Blue/Green deployment implementation under the key `blue-green-deploymen` (missing the trailing "t"). This PR corrects the typo and updates the single `$ref` in `BuildAndDeployment/Deployment.yaml` that points to it.

## Diff scope

- `src/assets/YAML/default/implementations.yaml` — key rename: `blue-green-deploymen:` → `blue-green-deployment:`
- `src/assets/YAML/default/BuildAndDeployment/Deployment.yaml` — `$ref` path update to match.

The implementation UUID (`4fb3d95c-07c0-4cbb-b396-5054aba751c2`) is unchanged. UUIDs are the stable identifiers in DSOMM; the YAML key is a path label only. Downstream consumers that resolve by UUID see no change.

## Verification

```bash
git grep 'blue-green-deploymen[^t]'   # empty - typo fully removed
git grep 'blue-green-deployment'      # 2 hits - the renamed key and its $ref
```

YAML syntax confirmed valid via `yaml.safe_load` on both files after the edit.

## Note

This was flagged as "Out of scope" in #76 (the Canary deployment activity PR) and is now followed up here as a separate focused PR per the project contribution guidelines (`Do not mix unrelated changes`).